### PR TITLE
[feat] 유저 id로 채소 전체 삭제 api

### DIFF
--- a/src/main/java/com/example/farmusfarm/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/example/farmusfarm/domain/challenge/service/ChallengeService.java
@@ -107,28 +107,9 @@ public class ChallengeService {
 
     }
 
-    // 챌린지 종료
-    public DeleteRegistrationResponseDto deleteRegistration(Long veggieId, Long challengeId) {
-        Registration registration = getVeggieRegistration(veggieId, challengeId);
-
-        registrationRepository.delete(registration);
-
-        return DeleteRegistrationResponseDto.of(registration.getId());
-    }
-
-    // 유저 별 전체 챌린지 조회
-    public List<Registration> getUserRegistrationList(Long userId) {
-        return registrationRepository.findAllByUserId(userId);
-    }
-
     // 유저 별 등록 정보 조회
     public Registration getUserRegistration(Long userId, Long challengeId) {
         return registrationRepository.findByUserIdAndChallengeId(userId, challengeId)
-                .orElseThrow(() -> new IllegalArgumentException("등록 정보가 존재하지 않습니다."));
-    }
-
-    public Registration getVeggieRegistration(Long veggieId, Long challengeId) {
-        return registrationRepository.findByVeggieIdAndChallengeId(veggieId, challengeId)
                 .orElseThrow(() -> new IllegalArgumentException("등록 정보가 존재하지 않습니다."));
     }
 
@@ -305,7 +286,7 @@ public class ChallengeService {
                 getStatusCount(challenge.getStartedAt()),
                 null,
                 0,
-                "",
+                "준비물을 챙겨요",
                 "",
                 new ArrayList<String>(),
                 null

--- a/src/main/java/com/example/farmusfarm/domain/veggie/controller/VeggieController.java
+++ b/src/main/java/com/example/farmusfarm/domain/veggie/controller/VeggieController.java
@@ -114,4 +114,11 @@ public class VeggieController {
         Long userId = Long.valueOf(jwtTokenProvider.getUserId(request));
         return BaseResponseDto.of(SuccessMessage.SUCCESS, veggieService.finishFarm(requestDto, userId));
     }
+
+    @DeleteMapping("/{userId}")
+    public void deleteAllVeggies(
+            @PathVariable Long userId
+    ) {
+        veggieService.deleteAllVeggies(userId);
+    }
 }

--- a/src/main/java/com/example/farmusfarm/domain/veggie/repository/VeggieRepository.java
+++ b/src/main/java/com/example/farmusfarm/domain/veggie/repository/VeggieRepository.java
@@ -13,4 +13,7 @@ public interface VeggieRepository extends JpaRepository<Veggie, Long> {
     List<Long> findAllVeggiesIdByUserId(Long userId);
 
     List<Veggie> findAllByUserId(Long userId);
+
+    // 유저 id로 채소 전부 삭제
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/example/farmusfarm/domain/veggie/service/VeggieService.java
+++ b/src/main/java/com/example/farmusfarm/domain/veggie/service/VeggieService.java
@@ -164,6 +164,10 @@ public class VeggieService {
         return FinishFarmResponseDto.of(true);
     }
 
+    public void deleteAllVeggies(Long userId) {
+        veggieRepository.deleteAllByUserId(userId);
+    }
+
     // -------------------- api --------------------
 
     public List<CreateHistoryDetailRequestDto.HistoryPost> getHistoryPosts(List<Diary> diaries) {


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : close #1 


### 🍠 Summary
유저가 삭제될 경우 팜 서비스의 해당 유저 관련 데이터 삭제를 위한 api


### 🥔 Commits
- 유저 id로 채소 전체 삭제 api(페인용)


### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
